### PR TITLE
Fix FB login

### DIFF
--- a/src/simpleauth/handler.py
+++ b/src/simpleauth/handler.py
@@ -103,7 +103,7 @@ class SimpleAuthHandler(object):
     'google'      : '_json_parser',
     'windows_live': '_json_parser',
     'foursquare'  : '_json_parser',
-    'facebook'    : '_query_string_parser',
+    'facebook'    : '_json_parser',
     'linkedin'    : '_query_string_parser',
     'linkedin2'    : '_json_parser',
     'twitter'     : '_query_string_parser'


### PR DESCRIPTION
There was a breaking change in the facebook api from 2.2 -> 2.3. Support for 2.2 was dropped on the 27th March 2017.
https://developers.facebook.com/docs/apps/changelog